### PR TITLE
WrenSec Builds - Phase #1 (for wrensec-persistit)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,14 @@
+export MAVEN_PACKAGE="forgerock-persistit"
+export BINTRAY_PACKAGE="wrensec-persistit"
+export JFROG_PACKAGE="org/forgerock/commons/forgerock-persistit"
+
+package_accept_release_tag() {
+  local tag_name="${1}"
+
+  if [ "${tag_name}" != "4.3.1" ]; then
+    echo "Skipping ${tag_name} since we only want to build 4.3.1 right now."
+    return -1
+  else
+    return 0
+  fi
+}

--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -2,6 +2,10 @@ export MAVEN_PACKAGE="forgerock-persistit"
 export BINTRAY_PACKAGE="wrensec-persistit"
 export JFROG_PACKAGE="org/forgerock/commons/forgerock-persistit"
 
+# Per Peter Major: "The actual release was built with -DskipTests too..."
+# Source: https://gist.github.com/aldaris/fe234d76f3940c42ae9bb5aa69b8e98e
+export MVN_COMPILE_ARGS="${WREN_DEFAULT_MVN_COMPILE_ARGS:-} -DskipTests"
+
 package_accept_release_tag() {
   local tag_name="${1}"
 

--- a/persistit-core/pom.xml
+++ b/persistit-core/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>forgerock-persistit-core</artifactId>
   <packaging>jar</packaging>
 
-  <name>forgerock-persistit-core</name>
+  <name>Wren Persistit Core</name>
 
   <dependencies>
     <dependency>

--- a/persistit-ui/pom.xml
+++ b/persistit-ui/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>forgerock-persistit-ui</artifactId>
   <packaging>jar</packaging>
 
-  <name>forgerock-persistit-ui</name>
+  <name>Wren Persistit UI</name>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,14 +13,14 @@
   <version>4.3.1</version>
   <packaging>pom</packaging>
 
-  <name>ForgeRock Persistit</name>
+  <name>Wren Persistit</name>
   <description>Java B+Tree Key-Value Store Library</description>
   <inceptionYear>2005</inceptionYear>
-  <url>https://stash.forgerock.org/projects/COMMONS/repos/forgerock-persistit</url>
+  <url>http://wrensecurity.org</url>
 
   <organization>
-    <name>ForgeRock</name>
-    <url>http://www.forgerock.com</url>
+    <name>Wren Security</name>
+    <url>http://wrensecurity.org</url>
   </organization>
 
   <modules>
@@ -37,33 +37,39 @@
   </licenses>
 
   <scm>
-    <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-persistit.git</developerConnection>
-    <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-persistit.git</connection>
-    <url>https://stash.forgerock.org/projects/COMMONS/repos/forgerock-persistit/browse</url>
-    <tag>4.3.1</tag>
+    <url>https://github.com/WrenSecurity/wrensec-persistit</url>
+    <connection>scm:git:git://github.com/WrenSecurity/wrensec-persistit.git</connection>
+    <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-persistit.git</developerConnection>
   </scm>
 
   <distributionManagement>
     <snapshotRepository>
-      <id>forgerock-snapshots</id>
-      <name>ForgeRock Snapshot Repository</name>
+      <id>wrensecurity-snapshots</id>
+      <name>Wren Security Snapshot Repository</name>
       <url>${forgerockDistMgmtSnapshotsUrl}</url>
     </snapshotRepository>
+
     <repository>
-      <id>forgerock-staging</id>
-      <name>ForgeRock Release Repository</name>
+      <id>wrensecurity-releases</id>
+      <name>Wren Security Release Repository</name>
       <url>${forgerockDistMgmtReleasesUrl}</url>
     </repository>
   </distributionManagement>
   
   <repositories>
+    <!-- Needed to retrieve parent POM -->
     <repository>
-      <id>forgerock-staging-repository</id>
-      <name>ForgeRock Release Repository</name>
-      <url>${forgerockDistMgmtReleasesUrl}</url>
+      <id>wrensecurity-releases</id>
+      <name>Wren Security Release Repository</name>
+      <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+
+      <releases>
+        <enabled>true</enabled>
+      </releases>
     </repository>
   </repositories>
 
@@ -74,8 +80,6 @@
     <animal-sniffer.signature.version>1.0</animal-sniffer.signature.version>
     <version.animal-sniffer.plugin>1.11</version.animal-sniffer.plugin>
     <version.maven-license.plugin>2.6</version.maven-license.plugin>
-    <forgerockDistMgmtSnapshotsUrl>http://maven.forgerock.org/repo/snapshots</forgerockDistMgmtSnapshotsUrl>
-    <forgerockDistMgmtReleasesUrl>http://maven.forgerock.org/repo/releases</forgerockDistMgmtReleasesUrl>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
- modifies the POMs to build using Wren's repos.
- updates branding to call this Wren Persistit instead of ForgeRock Persistit.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.