### PR TITLE
Prepare 4.3.2 release to fix OPENDJ-2753

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -3,14 +3,3 @@ export MAVEN_PACKAGE="forgerock-persistit"
 # Per Peter Major: "The actual release was built with -DskipTests too..."
 # Source: https://gist.github.com/aldaris/fe234d76f3940c42ae9bb5aa69b8e98e
 export MVN_COMPILE_ARGS="${WREN_DEFAULT_MVN_COMPILE_ARGS:-} -DskipTests"
-
-package_accept_release_tag() {
-  local tag_name="${1}"
-
-  if [ "${tag_name}" != "4.3.1" ]; then
-    echo "Skipping ${tag_name} since we only want to build 4.3.1 right now."
-    return -1
-  else
-    return 0
-  fi
-}

--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,6 +1,4 @@
 export MAVEN_PACKAGE="forgerock-persistit"
-export BINTRAY_PACKAGE="wrensec-persistit"
-export JFROG_PACKAGE="org/forgerock/commons/forgerock-persistit"
 
 # Per Peter Major: "The actual release was built with -DskipTests too..."
 # Source: https://gist.github.com/aldaris/fe234d76f3940c42ae9bb5aa69b8e98e

--- a/persistit-core/pom.xml
+++ b/persistit-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-persistit</artifactId>
-    <version>4.3.1</version>
+    <version>4.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>forgerock-persistit-core</artifactId>

--- a/persistit-core/pom.xml
+++ b/persistit-core/pom.xml
@@ -79,6 +79,28 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>1.4</version>
+
+        <executions>
+          <execution>
+            <id>generate-buildnumber</id>
+
+            <goals>
+              <goal>create</goal>
+            </goals>
+
+            <configuration>
+              <buildNumberPropertyName>buildRevision</buildNumberPropertyName>
+              <shortRevisionLength>11</shortRevisionLength>
+              <revisionOnScmFailure>-1</revisionOnScmFailure>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/persistit-core/pom.xml
+++ b/persistit-core/pom.xml
@@ -18,12 +18,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
@@ -40,6 +40,7 @@
           <include>LICENSE.txt</include>
         </includes>
       </resource>
+
       <resource>
         <directory>src/main/resources</directory>
         <filtering>true</filtering>
@@ -47,6 +48,7 @@
           <include>com/persistit/persistit_version</include>
         </includes>
       </resource>
+
       <resource>
         <directory>src/main/resources</directory>
         <filtering>false</filtering>
@@ -61,15 +63,18 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>rmic-maven-plugin</artifactId>
       </plugin>
+
       <!-- check copyright/license headers -->
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>

--- a/persistit-core/src/main/resources/com/persistit/persistit_version
+++ b/persistit-core/src/main/resources/com/persistit/persistit_version
@@ -1,1 +1,1 @@
-${project.version}.${BZR_REVISION}
+${project.version} (rev ${buildRevision})

--- a/persistit-ui/pom.xml
+++ b/persistit-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-persistit</artifactId>
-    <version>4.3.1</version>
+    <version>4.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>forgerock-persistit-ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.forgerock</groupId>
-    <artifactId>forgerock-parent</artifactId>
-    <version>2.0.3</version>
+    <groupId>org.wrensecurity</groupId>
+    <artifactId>wrensec-parent</artifactId>
+    <version>2.2.0</version>
   </parent>
 
   <groupId>org.forgerock.commons</groupId>
@@ -80,6 +80,8 @@
     <animal-sniffer.signature.version>1.0</animal-sniffer.signature.version>
     <version.animal-sniffer.plugin>1.11</version.animal-sniffer.plugin>
     <version.maven-license.plugin>2.6</version.maven-license.plugin>
+
+    <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.2.0</pgpWhitelistArtifact>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.forgerock.commons</groupId>
   <artifactId>forgerock-persistit</artifactId>
-  <version>4.3.1</version>
+  <version>4.3.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Wren Persistit</name>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <url>${forgerockDistMgmtReleasesUrl}</url>
     </repository>
   </distributionManagement>
-  
+
   <repositories>
     <!-- Needed to retrieve parent POM -->
     <repository>
@@ -89,14 +89,14 @@
         <artifactId>slf4j-api</artifactId>
         <version>1.7.7</version>
       </dependency>
-      
+
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.11</version>
         <scope>test</scope>
       </dependency>
-      
+
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
@@ -132,7 +132,7 @@
             </execution>
           </executions>
         </plugin>
-        
+
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
@@ -152,7 +152,7 @@
             </execution>
           </executions>
         </plugin>
-        
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -168,7 +168,7 @@
             </includes>
           </configuration>
         </plugin>
-        
+
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>rmic-maven-plugin</artifactId>
@@ -185,7 +185,7 @@
             </execution>
           </executions>
         </plugin>
-        
+
         <!-- check copyright/license headers -->
         <plugin>
           <groupId>com.mycila</groupId>


### PR DESCRIPTION
Wren:DS 3.5.1 and Wren:DS 4.x (`master`) depend on `forgerock-persistit-core-4.3.2`. Previously, to get 3.5.1 buildable, we were using an archived binary artifact that was obtained from the [Evolveum Maven repo](http://nexus.evolveum.com/nexus/content/repositories/forgerock/org/forgerock/commons/forgerock-persistit-core/4.3.2/).

Diffing the contents of the binary jars, it looks like the only change that FR made between 4.3.1 and 4.3.2 was a fix for [OPENDJ-2753](https://bugster.forgerock.org/jira/browse/OPENDJ-2753), to correct build revision stamping:
![image](https://user-images.githubusercontent.com/27592108/44440570-acf1b800-a596-11e8-81ec-b538ef9b0dea.png)

This PR updates the `forgerock-persistit` project for the latest PGP verification and parent POM changes, and then applies the fix for OPENDJ-2753.